### PR TITLE
전역상태값으로 관리해야 하는 부분들 추가

### DIFF
--- a/src/components/ControlSection/index.tsx
+++ b/src/components/ControlSection/index.tsx
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { componentNameList } from "../../constants";
 import { Chip } from "../../design-system/components";
 import { componentSchemaMap } from "../../schema";
-import { componentPropsState } from "../../store";
+import { activeComponentChipIndex, componentPropsState } from "../../store";
 import { composeComponentPropsData } from "../../utils";
 
 import { ComponentControlPanel } from "./ComponentControlPanel";
@@ -27,8 +27,7 @@ export const ControlSection = () => {
 };
 
 const ComponentPanelGroup = () => {
-  const [activeIndex, setActiveIndex] = React.useState(0);
-
+  const [activeIndex, setActiveIndex] = useRecoilState(activeComponentChipIndex);
   const [componentProps, setComponentProps] = useRecoilState(componentPropsState);
 
   const componentName = componentNameList[activeIndex];

--- a/src/components/StoryPlaySection/index.tsx
+++ b/src/components/StoryPlaySection/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Control, FieldValues, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import classNames from "classnames/bind";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { z } from "zod";
 
 import { storyComponentNameList } from "../../constants";
@@ -25,7 +25,7 @@ import {
   Typography,
   TypographyProps,
 } from "../../design-system/components";
-import { componentPropsState } from "../../store";
+import { componentPropsState, storyPlaygroundFormState } from "../../store";
 import { DraggableWrapper } from "../DraggableWrapper";
 
 import styles from "./styles.module.scss";
@@ -44,24 +44,15 @@ const schema = z.object({
   isLoading: z.boolean(),
 });
 
-const defaultValues = {
-  Typography: false,
-  Badge: false,
-  Button: false,
-  Chip: false,
-  Toggler: false,
-  FoldingMotion: false,
-  AccordionCard: false,
-  ProductList: false,
-};
-
 type FormValues = z.infer<typeof schema>;
 
 export const StoryPlaySection = () => {
+  const [formState, setFormState] = useRecoilState(storyPlaygroundFormState);
+
   const { getValues, setValue, control } = useForm<FormValues>({
     mode: "onChange",
     resolver: zodResolver(schema),
-    defaultValues,
+    defaultValues: formState,
   });
 
   const options = useWatch({
@@ -80,6 +71,7 @@ export const StoryPlaySection = () => {
               disabled={options.isLoading}
               onClick={() => {
                 setValue(componentName, !getValues(componentName));
+                setFormState(getValues());
               }}
             />
           );

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,3 +11,17 @@ export const componentPropsState = atom<Record<string, object>>({
   key: "componentProps",
   default: defaultComponentProps,
 });
+
+export const storyPlaygroundFormState = atom({
+  key: "storyPlaygroundForm",
+  default: {
+    Typography: false,
+    Badge: false,
+    Button: false,
+    Chip: false,
+    Toggler: false,
+    FoldingMotion: false,
+    AccordionCard: false,
+    ProductList: false,
+  },
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,11 @@ export const playgroundState = atom<"test" | "story">({
   default: "test",
 });
 
+export const activeComponentChipIndex = atom<number>({
+  key: "activeComponentChipIndex",
+  default: 0,
+});
+
 export const componentPropsState = atom<Record<string, object>>({
   key: "componentProps",
   default: defaultComponentProps,


### PR DESCRIPTION
- [X] Story Playground 페이지에 추가해뒀던 컴포넌트 정보
- [X] Test Playground에서 선택했던 컴포넌트 칩 index 정보

=> Test Playground, Story Playground 두 탭을 넘나들면서 다녀도 상태값이 전역적으로 유지됨으로 사용자가 변경한 내용이 그대로 남아 있게 됨.